### PR TITLE
Small fix to support deployment with reltoo/rebar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+all: compile
+
+compile:
+	@./rebar compile

--- a/src/ossp_uuid.erl
+++ b/src/ossp_uuid.erl
@@ -11,7 +11,7 @@
 init() ->
     case code:which(?MODULE) of
         Filename when is_list(Filename) ->
-            erlang:load_nif(filename:join([filename:dirname(Filename),"../priv/ossp_uuid_drv"]), []);
+            erlang:load_nif(filename:join([code:priv_dir(ossp_uuid), "ossp_uuid_drv"]), []);
         Err ->
             Err
     end.


### PR DESCRIPTION
When deploying any application that relies on ossp_uuid, there's an issue where the priv folder isn't properly referenced. As a result the NIF can't be loaded and the application won't run.

This small change fixes that problem.
