### PR TITLE
Fix architecture mismatch when linking native code on OSX 10.6

### DIFF
--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -10,6 +10,7 @@ ERLWS=`erl -noshell -eval "io:format(\"~p\",[erlang:system_info(wordsize)])" -s 
 
 if [ "$ERLWS" == 4 ]; then
    CFLAGS=-m32
+   LDFLAGS=-m32
 fi
 
-[ -d deps/uuid-1.6.2 ] || (cd deps && tar xzvfp uuid-1.6.2.tar.gz && cd uuid-1.6.2 && CFLAGS=$CFLAGS ./configure -disable-debug --without-perl --without-php --without-pgsql && make)
+[ -d deps/uuid-1.6.2 ] || (cd deps && tar xzvfp uuid-1.6.2.tar.gz && cd uuid-1.6.2 && CFLAGS=$CFLAGS LDFLAGS=$LDFLAGS ./configure -disable-debug --without-perl --without-php --without-pgsql && make)


### PR DESCRIPTION
Fixes a linking problem on Mac OSX 10.6 (Snow Leopard). Link failure message:

ld: warning: ignoring file uuid_cli.o, file was built for i386 which is not the architecture being linked (x86_64)
