### PR TITLE
Fixed syntax error in prepare.sh

### DIFF
--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -8,7 +8,7 @@ fi
 
 ERLWS=`erl -noshell -eval "io:format(\"~p\",[erlang:system_info(wordsize)])" -s erlang halt`
 
-if [ "$ERLWS" == 4 ]; then
+if [ "$ERLWS" = 4 ]; then
    CFLAGS=-m32
    LDFLAGS=-m32
 fi


### PR DESCRIPTION
Boolean operator '==' does not exist in sh scripts (introduced in it's derivatives).
replaced with '='.